### PR TITLE
Android automatic refactor - ObsoleteLayoutParam

### DIFF
--- a/app/src/main/res/layout/activity_map_geo_picker.xml
+++ b/app/src/main/res/layout/activity_map_geo_picker.xml
@@ -1,39 +1,22 @@
 <?xml version='1.0' encoding='utf-8'?>
   <!--
   /*
-
  * Copyright (c) 2015 by k3b.
-
  *
-
  * This file is part of AndroFotoFinder.
-
  *
-
  * This program is free software: you can redistribute it and/or modify it
-
  * under the terms of the GNU General Public License as published by
-
  * the Free Software Foundation, either version 3 of the License, or
-
  * (at your option) any later version.
-
  *
-
  * This program is distributed in the hope that it will be useful, but WITHOUT
-
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License
-
  * for more details.
-
  *
-
  * You should have received a copy of the GNU General Public License along with
-
  * this program. If not, see <http://www.gnu.org/licenses/>
-
  */
 
  -->

--- a/app/src/main/res/layout/activity_map_geo_picker.xml
+++ b/app/src/main/res/layout/activity_map_geo_picker.xml
@@ -1,34 +1,52 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-/*
- * Copyright (c) 2015 by k3b.
- *
- * This file is part of AndroFotoFinder.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU General Public License
- * for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program. If not, see <http://www.gnu.org/licenses/>
- */
- -->
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context="de.k3b.android.androFotoFinder.locationmap.MapGeoPickerActivity">
-    <fragment
-        android:id="@+id/fragment_map"
-        android:name="de.k3b.android.androFotoFinder.locationmap.PickerLocationMapFragment"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_weight="4" />
+<?xml version='1.0' encoding='utf-8'?>
+  <!--
+  /*
 
+ * Copyright (c) 2015 by k3b.
+
+ *
+
+ * This file is part of AndroFotoFinder.
+
+ *
+
+ * This program is free software: you can redistribute it and/or modify it
+
+ * under the terms of the GNU General Public License as published by
+
+ * the Free Software Foundation, either version 3 of the License, or
+
+ * (at your option) any later version.
+
+ *
+
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License
+
+ * for more details.
+
+ *
+
+ * You should have received a copy of the GNU General Public License along with
+
+ * this program. If not, see <http://www.gnu.org/licenses/>
+
+ */
+
+ -->
+   <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+   xmlns:tools="http://schemas.android.com/tools"
+   android:layout_width="match_parent"
+   android:layout_height="match_parent"
+   tools:context="de.k3b.android.androFotoFinder.locationmap.MapGeoPickerActivity">
+
+  <fragment android:id="@+id/fragment_map"
+    android:name="de.k3b.android.androFotoFinder.locationmap.PickerLocationMapFragment"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <!--Removed ObsoleteLayoutParam: layout_weight-->
+  </fragment>
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_gallery.xml
+++ b/app/src/main/res/layout/fragment_gallery.xml
@@ -1,166 +1,248 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-/*
+<?xml version='1.0' encoding='utf-8'?>
+  <!--
+  /*
+
  * Copyright (c) 2015 by k3b.
+
  *
+
  * This file is part of AndroFotoFinder.
+
  *
+
  * This program is free software: you can redistribute it and/or modify it
+
  * under the terms of the GNU General Public License as published by
+
  * the Free Software Foundation, either version 3 of the License, or
+
  * (at your option) any later version.
+
  *
+
  * This program is distributed in the hope that it will be useful, but WITHOUT
+
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License
+
  * for more details.
+
  *
+
  * You should have received a copy of the GNU General Public License along with
+
  * this program. If not, see <http://www.gnu.org/licenses/>
+
  */
+
  -->
+   <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+   android:layout_width="match_parent"
+   android:layout_height="match_parent"
+   android:orientation="vertical">
+  <!--
 
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    >
-    <!--
     [HorizontalScrollView-parent_scroller[parent_owner[[parentButton] [parentButton] [parentButton] ...]]]
+
     [HorizontalScrollView-child_scroller [child_owner [[childButton ] [childButton ] [childButton ] ...]]]
+
     [GridView-gridView]
+
     -->
-    <HorizontalScrollView
-        android:id="@+id/parent_scroller"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:scrollbars="horizontal"
-        android:scrollbarSize="2dp"
-        android:scrollbarStyle="insideInset"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentTop="true"
-        >
-        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-            android:id="@+id/parent_owner"
-            android:orientation="horizontal"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            >
 
-            <!-- path bar goes here as dynamically inserted buttons -->
-            <!-- to see it in layout-editor uncomment this
+  <HorizontalScrollView android:id="@+id/parent_scroller"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:scrollbars="horizontal"
+    android:scrollbarSize="2dp"
+    android:scrollbarStyle="insideInset">
+
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+      android:id="@+id/parent_owner"
+      android:orientation="horizontal"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content">
+      <!-- path bar goes here as dynamically inserted buttons -->
+      <!-- to see it in layout-editor uncomment this
+
             <Button
+
                 android:layout_width="wrap_content"
+
                 android:layout_height="wrap_content"
-                android:text="path goes here" />
-            <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+
                 android:text="path goes here"
-                />
+                  />
+
             <Button
+
                 android:layout_width="wrap_content"
+
                 android:layout_height="wrap_content"
+
                 android:text="path goes here"
+
                 />
+
             <Button
+
                 android:layout_width="wrap_content"
+
                 android:layout_height="wrap_content"
+
                 android:text="path goes here"
+
                 />
+
             <Button
+
                 android:layout_width="wrap_content"
+
                 android:layout_height="wrap_content"
+
                 android:text="path goes here"
+
                 />
+
             <Button
+
                 android:layout_width="wrap_content"
+
                 android:layout_height="wrap_content"
+
                 android:text="path goes here"
+
                 />
+
             <Button
+
                 android:layout_width="wrap_content"
+
                 android:layout_height="wrap_content"
+
                 android:text="path goes here"
+
                 />
+
+            <Button
+
+                android:layout_width="wrap_content"
+
+                android:layout_height="wrap_content"
+
+                android:text="path goes here"
+
+                />
+
             -->
+    </LinearLayout>
+    <!--Removed ObsoleteLayoutParam: layout_alignParentLeft-->
+    <!--Removed ObsoleteLayoutParam: layout_alignParentTop-->
+  </HorizontalScrollView>
 
-        </LinearLayout>
-    </HorizontalScrollView>
-    <HorizontalScrollView
-        android:id="@+id/child_scroller"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:scrollbars="horizontal"
-        android:scrollbarSize="2dp"
-        android:scrollbarStyle="insideInset"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentTop="true"
-        >
-        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-            android:id="@+id/child_owner"
-            android:orientation="horizontal"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            >
+  <HorizontalScrollView android:id="@+id/child_scroller"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:scrollbars="horizontal"
+    android:scrollbarSize="2dp"
+    android:scrollbarStyle="insideInset">
 
-            <!-- path bar goes here as dynamically inserted buttons -->
-            <!-- to see it in layout-editor uncomment this
-            <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="path goes here" />
-            <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="path goes here"
-                />
-            <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="path goes here"
-                />
-            <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="path goes here"
-                />
-            <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="path goes here"
-                />
-            <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="path goes here"
-                />
-            <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="path goes here"
-                />
--->
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+      android:id="@+id/child_owner"
+      android:orientation="horizontal"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content">
+      <!-- path bar goes here as dynamically inserted buttons -->
+      <!-- to see it in layout-editor uncomment this
 
-        </LinearLayout>
-    </HorizontalScrollView>
+            <Button
 
-    <GridView
-            android:orientation="horizontal"
-            android:background="#f0f0f0"
-            android:id="@+id/gridView"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/grid_cell_margin"
-            android:columnWidth="@dimen/grid_cell_width"
-            android:drawSelectorOnTop="true"
-            android:gravity="center"
-            android:numColumns="auto_fit"
-            android:stretchMode="columnWidth"
-            android:verticalSpacing="@dimen/grid_cell_margin"
-            android:horizontalSpacing="@dimen/grid_cell_margin"
-            android:focusable="true"
-            android:clickable="true"/>
+                android:layout_width="wrap_content"
 
+                android:layout_height="wrap_content"
+
+                android:text="path goes here"
+                  />
+
+            <Button
+
+                android:layout_width="wrap_content"
+
+                android:layout_height="wrap_content"
+
+                android:text="path goes here"
+
+                />
+
+            <Button
+
+                android:layout_width="wrap_content"
+
+                android:layout_height="wrap_content"
+
+                android:text="path goes here"
+
+                />
+
+            <Button
+
+                android:layout_width="wrap_content"
+
+                android:layout_height="wrap_content"
+
+                android:text="path goes here"
+
+                />
+
+            <Button
+
+                android:layout_width="wrap_content"
+
+                android:layout_height="wrap_content"
+
+                android:text="path goes here"
+
+                />
+
+            <Button
+
+                android:layout_width="wrap_content"
+
+                android:layout_height="wrap_content"
+
+                android:text="path goes here"
+
+                />
+
+            <Button
+
+                android:layout_width="wrap_content"
+
+                android:layout_height="wrap_content"
+
+                android:text="path goes here"
+
+                />
+                  -->
+    </LinearLayout>
+    <!--Removed ObsoleteLayoutParam: layout_alignParentLeft-->
+    <!--Removed ObsoleteLayoutParam: layout_alignParentTop-->
+  </HorizontalScrollView>
+
+  <GridView android:orientation="horizontal"
+    android:background="#f0f0f0"
+    android:id="@+id/gridView"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_margin="@dimen/grid_cell_margin"
+    android:columnWidth="@dimen/grid_cell_width"
+    android:drawSelectorOnTop="true"
+    android:gravity="center"
+    android:numColumns="auto_fit"
+    android:stretchMode="columnWidth"
+    android:verticalSpacing="@dimen/grid_cell_margin"
+    android:horizontalSpacing="@dimen/grid_cell_margin"
+    android:focusable="true"
+    android:clickable="true"/>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_gallery.xml
+++ b/app/src/main/res/layout/fragment_gallery.xml
@@ -1,39 +1,22 @@
 <?xml version='1.0' encoding='utf-8'?>
   <!--
   /*
-
  * Copyright (c) 2015 by k3b.
-
  *
-
  * This file is part of AndroFotoFinder.
-
  *
-
  * This program is free software: you can redistribute it and/or modify it
-
  * under the terms of the GNU General Public License as published by
-
  * the Free Software Foundation, either version 3 of the License, or
-
  * (at your option) any later version.
-
  *
-
  * This program is distributed in the hope that it will be useful, but WITHOUT
-
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License
-
  * for more details.
-
  *
-
  * You should have received a copy of the GNU General Public License along with
-
  * this program. If not, see <http://www.gnu.org/licenses/>
-
  */
 
  -->
@@ -42,13 +25,9 @@
    android:layout_height="match_parent"
    android:orientation="vertical">
   <!--
-
     [HorizontalScrollView-parent_scroller[parent_owner[[parentButton] [parentButton] [parentButton] ...]]]
-
     [HorizontalScrollView-child_scroller [child_owner [[childButton ] [childButton ] [childButton ] ...]]]
-
     [GridView-gridView]
-
     -->
 
   <HorizontalScrollView android:id="@+id/parent_scroller"
@@ -65,74 +44,40 @@
       android:layout_height="wrap_content">
       <!-- path bar goes here as dynamically inserted buttons -->
       <!-- to see it in layout-editor uncomment this
-
             <Button
-
                 android:layout_width="wrap_content"
-
                 android:layout_height="wrap_content"
-
                 android:text="path goes here"
                   />
-
             <Button
-
                 android:layout_width="wrap_content"
-
                 android:layout_height="wrap_content"
-
                 android:text="path goes here"
-
                 />
-
             <Button
-
                 android:layout_width="wrap_content"
-
                 android:layout_height="wrap_content"
-
                 android:text="path goes here"
-
                 />
-
             <Button
-
                 android:layout_width="wrap_content"
-
                 android:layout_height="wrap_content"
-
                 android:text="path goes here"
-
                 />
-
             <Button
-
                 android:layout_width="wrap_content"
-
                 android:layout_height="wrap_content"
-
                 android:text="path goes here"
-
                 />
-
             <Button
-
                 android:layout_width="wrap_content"
-
                 android:layout_height="wrap_content"
-
                 android:text="path goes here"
-
                 />
-
             <Button
-
                 android:layout_width="wrap_content"
-
                 android:layout_height="wrap_content"
-
                 android:text="path goes here"
-
                 />
 
             -->
@@ -155,74 +100,40 @@
       android:layout_height="wrap_content">
       <!-- path bar goes here as dynamically inserted buttons -->
       <!-- to see it in layout-editor uncomment this
-
             <Button
-
                 android:layout_width="wrap_content"
-
                 android:layout_height="wrap_content"
-
                 android:text="path goes here"
                   />
-
             <Button
-
                 android:layout_width="wrap_content"
-
                 android:layout_height="wrap_content"
-
                 android:text="path goes here"
-
                 />
-
             <Button
-
                 android:layout_width="wrap_content"
-
                 android:layout_height="wrap_content"
-
                 android:text="path goes here"
-
                 />
-
             <Button
-
                 android:layout_width="wrap_content"
-
                 android:layout_height="wrap_content"
-
                 android:text="path goes here"
-
                 />
-
             <Button
-
                 android:layout_width="wrap_content"
-
                 android:layout_height="wrap_content"
-
                 android:text="path goes here"
-
                 />
-
             <Button
-
                 android:layout_width="wrap_content"
-
                 android:layout_height="wrap_content"
-
                 android:text="path goes here"
-
                 />
-
             <Button
-
                 android:layout_width="wrap_content"
-
                 android:layout_height="wrap_content"
-
                 android:text="path goes here"
-
                 />
                   -->
     </LinearLayout>


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "ObsoleteLayoutParam".

While developing your application's views you might be specifying attributes in a view's artefact that are not necessary due to the nature of its parent. In this PR, those attributes were replaced by a comment.

I have made a previous validation of the changes and they seem correct.
Unfortunately, this tool is not able keep the original whitespace of the files, so comparison without ignoring whitespace might be confusing.
Please consider the changes and let me know if you agree with them.

Best,
Luis